### PR TITLE
Switch to new app package

### DIFF
--- a/cmd/rallymka/internal/ecs/renderer.go
+++ b/cmd/rallymka/internal/ecs/renderer.go
@@ -2,7 +2,6 @@ package ecs
 
 import (
 	"github.com/mokiat/gomath/sprec"
-	"github.com/mokiat/lacking/game"
 	"github.com/mokiat/lacking/render"
 )
 
@@ -18,7 +17,7 @@ type Renderer struct {
 	scene      *render.Scene
 }
 
-func (r *Renderer) Update(ctx game.UpdateContext) {
+func (r *Renderer) Update() {
 	for _, entity := range r.ecsManager.Entities() {
 		renderComp := entity.Render
 		physicsComp := entity.Physics

--- a/cmd/rallymka/internal/ecs/stand.go
+++ b/cmd/rallymka/internal/ecs/stand.go
@@ -1,8 +1,10 @@
 package ecs
 
 import (
+	"time"
+
 	"github.com/mokiat/gomath/sprec"
-	"github.com/mokiat/lacking/game"
+	"github.com/mokiat/lacking/app"
 )
 
 func NewCameraStandSystem(ecsManager *Manager) *CameraStandSystem {
@@ -15,15 +17,15 @@ type CameraStandSystem struct {
 	ecsManager *Manager
 }
 
-func (s *CameraStandSystem) Update(ctx game.UpdateContext) {
+func (s *CameraStandSystem) Update(elapsedTime time.Duration, gamepad *app.GamepadState) {
 	for _, entity := range s.ecsManager.Entities() {
 		if cameraStand := entity.CameraStand; cameraStand != nil {
-			s.updateCameraStand(cameraStand, ctx)
+			s.updateCameraStand(cameraStand, elapsedTime, gamepad)
 		}
 	}
 }
 
-func (s *CameraStandSystem) updateCameraStand(cameraStand *CameraStand, ctx game.UpdateContext) {
+func (s *CameraStandSystem) updateCameraStand(cameraStand *CameraStand, elapsedTime time.Duration, gamepad *app.GamepadState) {
 	var targetPosition sprec.Vec3
 	switch {
 	case cameraStand.Target.Physics != nil:
@@ -40,15 +42,15 @@ func (s *CameraStandSystem) updateCameraStand(cameraStand *CameraStand, ctx game
 	cameraVectorX := sprec.Vec3Cross(sprec.BasisYVec3(), cameraVectorZ)
 	cameraVectorY := sprec.Vec3Cross(cameraVectorZ, cameraVectorX)
 
-	if ctx.Gamepad.Available {
-		elapsedSeconds := float32(ctx.ElapsedTime.Seconds())
+	if gamepad != nil {
+		elapsedSeconds := float32(elapsedTime.Seconds())
 		rotationAmount := 200 * elapsedSeconds
-		if sprec.Abs(ctx.Gamepad.RightStickY) > 0.2 {
-			rotation := sprec.RotationQuat(sprec.Degrees(ctx.Gamepad.RightStickY*rotationAmount), cameraVectorX)
+		if sprec.Abs(gamepad.RightStickY) > 0.2 {
+			rotation := sprec.RotationQuat(sprec.Degrees(gamepad.RightStickY*rotationAmount), cameraVectorX)
 			anchorVector = sprec.QuatVec3Rotation(rotation, anchorVector)
 		}
-		if sprec.Abs(ctx.Gamepad.RightStickX) > 0.2 {
-			rotation := sprec.RotationQuat(sprec.Degrees(-ctx.Gamepad.RightStickX*rotationAmount), cameraVectorY)
+		if sprec.Abs(gamepad.RightStickX) > 0.2 {
+			rotation := sprec.RotationQuat(sprec.Degrees(-gamepad.RightStickX*rotationAmount), cameraVectorY)
 			anchorVector = sprec.QuatVec3Rotation(rotation, anchorVector)
 		}
 	}

--- a/cmd/rallymka/internal/game/simulation/view.go
+++ b/cmd/rallymka/internal/game/simulation/view.go
@@ -1,51 +1,75 @@
 package simulation
 
 import (
+	"time"
+
+	"github.com/mokiat/lacking/app"
 	"github.com/mokiat/lacking/async"
-	"github.com/mokiat/lacking/game"
-	"github.com/mokiat/lacking/input"
+	"github.com/mokiat/lacking/graphics"
 	"github.com/mokiat/lacking/resource"
 	"github.com/mokiat/rally-mka/cmd/rallymka/internal/scene"
 )
 
 func NewView(registry *resource.Registry, gfxWorker *async.Worker) *View {
 	return &View{
-		gameData: scene.NewData(registry, gfxWorker),
-		stage:    scene.NewStage(gfxWorker),
+		gfxWorker: gfxWorker,
+		gameData:  scene.NewData(registry, gfxWorker),
+		stage:     scene.NewStage(),
 	}
 }
 
 type View struct {
-	gameData *scene.Data
-	stage    *scene.Stage
+	gfxWorker *async.Worker
+	gameData  *scene.Data
+	stage     *scene.Stage
+
+	freezeFrame bool
 }
 
-func (v *View) Load() {
-	v.gameData.Request()
+func (v *View) Load(window app.Window, cb func()) {
+	loadOutcome := async.NewOutcome()
+	go func() {
+		v.gameData.Request().Wait()
+		v.stage.Init(v.gfxWorker, v.gameData)
+		loadOutcome.Record(async.Result{})
+	}()
+	go func() {
+		loadOutcome.Wait()
+		window.Schedule(func() error {
+			cb()
+			return nil
+		})
+	}()
 }
 
-func (v *View) Unload() {
+func (v *View) Unload(window app.Window) {
 	v.gameData.Dismiss()
 }
 
-func (v *View) IsAvailable() bool {
-	return v.gameData.IsAvailable()
+func (v *View) Open(window app.Window) {}
+
+func (v *View) Close(window app.Window) {}
+
+func (v *View) OnKeyboardEvent(window app.Window, event app.KeyboardEvent) bool {
+	if event.Code == app.KeyCodeF {
+		switch event.Type {
+		case app.KeyboardEventTypeKeyDown:
+			v.freezeFrame = true
+			return true
+		case app.KeyboardEventTypeKeyUp:
+			v.freezeFrame = false
+			return true
+		}
+	}
+	return v.stage.OnKeyboardEvent(event)
 }
 
-func (v *View) Open() {
-	v.stage.Init(v.gameData)
-}
-
-func (v *View) Close() {
-	// TODO: Erase stage
-}
-
-func (v *View) Update(ctx game.UpdateContext) {
-	if !ctx.Keyboard.IsPressed(input.KeyF) {
-		v.stage.Update(ctx)
+func (v *View) Update(window app.Window, elapsedTime time.Duration) {
+	if !v.freezeFrame {
+		v.stage.Update(window, elapsedTime)
 	}
 }
 
-func (v *View) Render(ctx game.RenderContext) {
-	v.stage.Render(ctx)
+func (v *View) Render(window app.Window, width, height int, pipeline *graphics.Pipeline) {
+	v.stage.Render(width, height, pipeline)
 }

--- a/cmd/rallymka/internal/scene/data.go
+++ b/cmd/rallymka/internal/scene/data.go
@@ -21,11 +21,12 @@ type Data struct {
 	Level    *resource.Level
 }
 
-func (d *Data) Request() {
+func (d *Data) Request() async.Outcome {
 	d.loadOutcome = async.NewCompositeOutcome(
 		d.registry.LoadModel("suv").OnSuccess(resource.InjectModel(&d.CarModel)),
 		d.registry.LoadLevel("forest").OnSuccess(resource.InjectLevel(&d.Level)),
 	)
+	return d.loadOutcome
 }
 
 func (d *Data) Dismiss() {

--- a/cmd/rallymka/main.go
+++ b/cmd/rallymka/main.go
@@ -2,25 +2,21 @@ package main
 
 import (
 	"log"
-	"time"
 
-	"github.com/mokiat/lacking/game"
-	rallygame "github.com/mokiat/rally-mka/cmd/rallymka/internal/game"
+	glfwapp "github.com/mokiat/lacking/glfw/app"
+	"github.com/mokiat/rally-mka/cmd/rallymka/internal/game"
 )
 
 func main() {
-	log.Println("game started")
-	app := game.NewApp(game.AppConfig{
-		WindowTitle:        "RallyMKA",
-		WindowWidth:        1024,
-		WindowHeight:       576,
-		WindowHideCursor:   true,
-		WindowVSync:        true,
-		UpdateLoopInterval: 16 * time.Millisecond,
-	})
-	controller := rallygame.NewController()
-	if err := app.Run(controller); err != nil {
-		log.Fatalf("game crashed: %v", err)
+	cfg := glfwapp.NewConfig("Rally MKA", 1024, 576)
+	cfg.SetVSync(true)
+	cfg.SetCursorVisible(false)
+	cfg.SetIcon("resources/icon.png")
+
+	controller := game.NewController()
+	log.Println("running application")
+	if err := glfwapp.Run(cfg, controller); err != nil {
+		log.Fatalf("application error: %v", err)
 	}
-	log.Println("game closed")
+	log.Println("application closed")
 }

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/mokiat/gomath v0.1.0
-	github.com/mokiat/lacking v0.1.1-0.20210428192151-3023d789d6d3
+	github.com/mokiat/lacking v0.1.1-0.20210430114045-d0907434d9f2
 )

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/mdouchement/hdr v0.2.3 h1:IxzxLgEarv9VPsk17DGIWnhA60MA5ASbekCU8YSFmaY
 github.com/mdouchement/hdr v0.2.3/go.mod h1:2Yb3JAST9c66wTLZ1vQrejU5sDeOC+ukXVs1pFAUtPo=
 github.com/mokiat/gomath v0.1.0 h1:wSBt+R4mT+9ndA3iPGKxWRAI+G/8Nmdic2xiCFC6hvc=
 github.com/mokiat/gomath v0.1.0/go.mod h1:KWlJ2no76F4c6nrnJ7VFwdMKtzbmQXfYuDzwJsm/Xng=
-github.com/mokiat/lacking v0.1.1-0.20210428192151-3023d789d6d3 h1:YpXeNRdZCDhQKoPGHM9omSkfJXHj4UgDBGS2QoEM9lE=
-github.com/mokiat/lacking v0.1.1-0.20210428192151-3023d789d6d3/go.mod h1:GF61qQ47jiL3QepaCn5bGwHwRyb1YZupUyHbspzFVQI=
+github.com/mokiat/lacking v0.1.1-0.20210430114045-d0907434d9f2 h1:HFSWeUJIXJIL0MA+n13o75YRpZ/du0eB+xZNBwfob5A=
+github.com/mokiat/lacking v0.1.1-0.20210430114045-d0907434d9f2/go.mod h1:GF61qQ47jiL3QepaCn5bGwHwRyb1YZupUyHbspzFVQI=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/resources/icon.png
+++ b/resources/icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4c4c3f17f43f872614271f0f9f0aed2a5fc536ac7519173d33e4fe656ca94fe
+size 2408


### PR DESCRIPTION
## Changes

This PR switches the implementation from the old `game` and `input` packages from `lacking` to the new `app` package.

In addition, it moves the update and render logic into the main UI thread. The former attempts to have rendering be done on a separate thread to save time did not yield any results, instead the code was harder to manage and it led to non-smooth rendering.

Lastly, this PR adds an initial app icon, which is not supported by the new app package.