### PR TITLE
Bump lacking dependency

### DIFF
--- a/cmd/rallymka/main.go
+++ b/cmd/rallymka/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	glfwapp "github.com/mokiat/lacking/glfw/app"
+	glfwapp "github.com/mokiat/lacking/framework/glfw/app"
 	"github.com/mokiat/rally-mka/cmd/rallymka/internal/game"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/mokiat/gomath v0.1.0
-	github.com/mokiat/lacking v0.1.1-0.20210510200218-6f639a7bb705
+	github.com/mokiat/lacking v0.1.1-0.20210512195510-8f82a92b8fa0
 )

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/mdouchement/hdr v0.2.3 h1:IxzxLgEarv9VPsk17DGIWnhA60MA5ASbekCU8YSFmaY
 github.com/mdouchement/hdr v0.2.3/go.mod h1:2Yb3JAST9c66wTLZ1vQrejU5sDeOC+ukXVs1pFAUtPo=
 github.com/mokiat/gomath v0.1.0 h1:wSBt+R4mT+9ndA3iPGKxWRAI+G/8Nmdic2xiCFC6hvc=
 github.com/mokiat/gomath v0.1.0/go.mod h1:KWlJ2no76F4c6nrnJ7VFwdMKtzbmQXfYuDzwJsm/Xng=
-github.com/mokiat/lacking v0.1.1-0.20210510200218-6f639a7bb705 h1:odrusvgAUwVMr53y9mmu9NMQtwoAc6aGC8clYzN0oeo=
-github.com/mokiat/lacking v0.1.1-0.20210510200218-6f639a7bb705/go.mod h1:GF61qQ47jiL3QepaCn5bGwHwRyb1YZupUyHbspzFVQI=
+github.com/mokiat/lacking v0.1.1-0.20210512195510-8f82a92b8fa0 h1:IDMgI/Bn75RNXRCdyDTxmJ7YqkrTZJ56ebpdm995fbU=
+github.com/mokiat/lacking v0.1.1-0.20210512195510-8f82a92b8fa0/go.mod h1:GF61qQ47jiL3QepaCn5bGwHwRyb1YZupUyHbspzFVQI=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
## Changes

This pull request bumps the lacking dependency to a newer version which includes mostly the following changes:

* The `glfw` package is relocated.
* The renderer uses the new `opengl` package (using opengl 4.6 DSA).
